### PR TITLE
Use the template config from API to build the config field/payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ vendor
 credentials
 key
 .idea
-import.yml
+import*.yml
+!import-sample.yml

--- a/import-sample.yml
+++ b/import-sample.yml
@@ -10,8 +10,10 @@ mappings:
         field_type: <css_selector or value>
         css_selector: <the selector value>  #used if css_selector
         value:  <direct value to be added>  #used if value
+        html: <true or false> #Whether text is HTML (true) or plain text (false)
     <field_name2>:
         mapped_field: <field_name_id_gathercontent>
         field_type: <css_selector or value>
         css_selector: <the selector value>
         value:  <direct value to be added>
+        html: <true or false> #Whether text is HTML (true) or plain text (false)

--- a/src/ContentScraper.php
+++ b/src/ContentScraper.php
@@ -8,10 +8,13 @@ class ContentScraper
     {
         $crawler = new Crawler($content);
 
-        $filtered = $crawler->filter($xpathSelector);
+        $filtered = $crawler->filter($xpathSelector[0]);
 
         if ($filtered->count() > 0) {
-            return $filtered->text();
+          if ($xpathSelector[1] === true) {
+            return $filtered->html();
+          }
+          return $filtered->text();
         }
 
         return '';

--- a/src/FieldNormaliser.php
+++ b/src/FieldNormaliser.php
@@ -2,7 +2,7 @@
 
 class FieldNormaliser
 {
-    public function normalise($hashMap = [], $projectId, $templateId)
+    public function normalise($hashMap = [], $projectId, $templateId, &$template)
     {
 
         /*
@@ -24,41 +24,24 @@ class FieldNormaliser
                     }]
                 }]
          */
-        $elements = array();
-        $default = new stdClass();
-        $default->type = "text";
-        $default->name = '';
-        $default->required = false;
-        $default->label = "";
-        $default->value = '';
-        $default->microcopy = "";
-        $default->limit_type = "words";
-        $default->limit = 0;
-        $default->plain_text = false;
-//var_dump($hashMap); exit;
-        foreach($hashMap as $id => $value) {
-            $field = clone $default;
-            $field->name = $id;
-            $field->value = $value;
-            $field->label = 'label-' . $id ;
-            $elements[] = $field;
+
+        foreach ($hashMap as $name => $value) {
+          if ($name !== 'name') {
+            foreach ($template->data->config as $key => $tab) {
+              foreach ($tab->elements as $k => $data) {
+                if ($data->name === $name) {
+                  $template->data->config[$key]->elements[$k]->value = $value;
+                }
+              }
+            }
+          }
         }
-        //var_dump($elements); exit;
-
-        $tab = new stdClass();
-        $tab->label = "Content";
-        $tab->name = "test";
-        $tab->hidden = false;
-        $tab->elements = $elements;
-
-        $config = [$tab];
-
         return [
           'project_id' => $projectId,
           'name' => $hashMap['name'],
-//            'parent_id' (optional)	Parent Item ID
+//        'parent_id' (optional)	Parent Item ID
           'template_id' => $templateId,
-          'config' => base64_encode(json_encode($config))
+          'config' => base64_encode(json_encode($template->data->config))
         ];
     }
 

--- a/src/ImportCommand.php
+++ b/src/ImportCommand.php
@@ -131,15 +131,16 @@ class ImportCommand extends Command
         $contentToFieldMapper = new ContentToFieldMapper();
         $normaliser           = new FieldNormaliser();
         $mapped = array(
-            'name' => 'title'
+            'name' => array('title', false),
         );
         //$mapped = array();
         $mappedValues = array();
         foreach ($mappings as $key => $value) {
+            $html_flag = (isset($value['html'])) ? $value['html'] : null;
             if ($value['field_type'] == 'value') {
-                $mappedValues[$value['mapped_field']] = $value['value'];
+                $mappedValues[$value['mapped_field']] = array($value['value'], $html_flag);
             } elseif ($value['field_type'] == 'css_selector') {
-                $mapped[$value['mapped_field']] = $value['css_selector'];
+              $mapped[$value['mapped_field']] = array($value['css_selector'], $html_flag);
             }
         }
         foreach ($urls as $url) {

--- a/src/ImportCommand.php
+++ b/src/ImportCommand.php
@@ -53,9 +53,7 @@ class ImportCommand extends Command
 
         $io->success('Connected to Gather Content.');
 
-        if ($input->getOption('template_id')) {
-            $this->lookupTemplate($username, $apiKey, $input->getOption('template_id'));
-        }
+        $template = $this->lookupTemplate($username, $apiKey, $templateId);
 
         // which account would you like to use?
         if (!$accountId = $this->config['account_id']) {
@@ -152,7 +150,7 @@ class ImportCommand extends Command
             );
             $hashMap = array_merge($hashMap, $mappedValues);
             //var_dump($hashMap);
-            $fields      = $normaliser->normalise($hashMap, $projectId, $templateId);
+            $fields = $normaliser->normalise($hashMap, $projectId, $templateId, $template);
             //var_dump($fields); exit;
             //print_r($fields); exit;
             $this->createItem($fields, $username, $apiKey);
@@ -200,11 +198,7 @@ class ImportCommand extends Command
         $jsonResponse = $this->httpClient->get('templates/' . $templateId, $options)->getBody();
         $response     = json_decode($jsonResponse);
 
-        return array_reduce($response->data->config[0]->elements, function ($elements, $element) {
-
-            $elements[$element->name] = $element->label;
-            return $elements;
-        }, []);
+        return $response;
     }
 
     private function createProject($username, $apiKey, $accountId, $projectName, $projectType)


### PR DESCRIPTION
This change grabs the template config from the API, and iterates through it replacing the value property with values from the scraper. This was recommended by Matt at GatherContent via a support chat.

This change also adds support for scraping HTML instead of plain text.